### PR TITLE
Fixing the typo of loading the expres instead of express

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
-    "expres": "0.0.5",
+    "express": "^4.18.1",
     "plaid": "^8.2.0"
   }
 }


### PR DESCRIPTION
Just correcting that I think you install "expres" (one s) instead of "express" 

Just helping because your youtube video helped me a LOT getting plaid up and running in a couple of minutes.

Thank you Tyler!